### PR TITLE
Format all human-purpose code

### DIFF
--- a/backend-project/config/settings/development.py
+++ b/backend-project/config/settings/development.py
@@ -4,12 +4,9 @@ DEBUG = True
 
 TEMPLATES[0]["OPTIONS"]["debug"] = True
 
-INSTALLED_APPS += [
-    "debug_toolbar",
-    "django_extensions"
-]
+INSTALLED_APPS += ["debug_toolbar", "django_extensions"]
 
-MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware", ] + MIDDLEWARE
+MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware",] + MIDDLEWARE
 
 INTERNAL_IPS = [
     "127.0.0.1",
@@ -17,9 +14,11 @@ INTERNAL_IPS = [
 
 ALLOWED_HOSTS = ["*"]
 DEBUG_TOOLBAR_CONFIG = {
-    'SHOW_TOOLBAR_CALLBACK': lambda r: r.environ.get('SERVER_NAME', None) != 'testserver' and (r.META.get('REMOTE_ADDR', None) in INTERNAL_IPS)
+    "SHOW_TOOLBAR_CALLBACK": lambda r: r.environ.get("SERVER_NAME", None)
+    != "testserver"
+    and (r.META.get("REMOTE_ADDR", None) in INTERNAL_IPS)
 }
 
 SECRET_KEY = "development"
 
-REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES'] = []
+REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = []

--- a/backend-project/config/settings/production.py
+++ b/backend-project/config/settings/production.py
@@ -3,4 +3,3 @@ from .base import *  # noqa
 SECRET_KEY = env("SECRET_KEY")
 
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS")
-

--- a/backend-project/pyproject.toml
+++ b/backend-project/pyproject.toml
@@ -4,28 +4,18 @@ target-version = ['py38']
 include = '.pyi?$'
 exclude = '''
 (
-  /(
-      \frontend-project
-    | \docs
-    | tests
-    | settings
-    | migrations
-    | \.github
-    | \.git
-    | \.eggs
-    | \.hg
-    | \.mypy_cache
-    | \.nox
-    | \.tox
-    | \.venv
-    | \venv             # pycharm
-    | \_build
-    | build
-    | dist
-  )/
-  |
-  /(
-    tests.py
-  )
+    \frontend-project
+  | migrations
+  | \.git
+  | \.eggs
+  | \.hg
+  | \.mypy_cache
+  | \.nox
+  | \.tox
+  | \.venv
+  | \venv             # pycharm
+  | \_build
+  | build
+  | dist
 )
 '''

--- a/backend-project/small_eod/cases/tests.py
+++ b/backend-project/small_eod/cases/tests.py
@@ -11,15 +11,17 @@ from django.urls import reverse
 # Create your tests here.
 class CaseCountSerializerTestCase(TestCase):
     def test_tag_field(self):
-        serializer = CaseSerializer(data={
-            "name": "Polska Fundacja Narodowa o rejestr umów",
-            "audited_institution": [],
-            "comment": "xxx",
-            "responsible_user": [],
-            "notified_user": [],
-            "feature": [],
-            "tag": ["rejestr umów"],
-        })
+        serializer = CaseSerializer(
+            data={
+                "name": "Polska Fundacja Narodowa o rejestr umów",
+                "audited_institution": [],
+                "comment": "xxx",
+                "responsible_user": [],
+                "notified_user": [],
+                "feature": [],
+                "tag": ["rejestr umów"],
+            }
+        )
         self.assertTrue(serializer.is_valid(), serializer.errors)
         obj = serializer.save()
         self.assertTrue(Tag.objects.count(), 1)
@@ -30,17 +32,19 @@ class CaseCountSerializerTestCase(TestCase):
     def test_raise_for_over_maximum_feature(self):
         dictionary = DictionaryFactory(max_items=3)
         features = FeatureFactory.create_batch(size=5, dictionary=dictionary)
-        serializer = CaseCountSerializer(data={
-            "name": "Polska Fundacja Narodowa o rejestr umów",
-            "audited_institution": [],
-            "comment": "xxx",
-            "responsible_user": [],
-            "notified_user": [],
-            "feature": [x.id for x in features],
-            "tag": [],
-        })
+        serializer = CaseCountSerializer(
+            data={
+                "name": "Polska Fundacja Narodowa o rejestr umów",
+                "audited_institution": [],
+                "comment": "xxx",
+                "responsible_user": [],
+                "notified_user": [],
+                "feature": [x.id for x in features],
+                "tag": [],
+            }
+        )
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(set(serializer.errors.keys()), {'feature'})
+        self.assertEqual(set(serializer.errors.keys()), {"feature"})
 
     def test_serializer_counters(self):
         CaseFactory()
@@ -51,8 +55,9 @@ class CaseCountSerializerTestCase(TestCase):
         self.assertEqual(data["letter_count"], 0)
         self.assertEqual(data["note_count"], 0)
 
+
 class CaseViewSetTestCase(GenericViewSetMixin, TestCase):
-    basename = 'case'
+    basename = "case"
     serializer_class = CaseSerializer
     factory_class = CaseFactory
 

--- a/backend-project/small_eod/collections/tests.py
+++ b/backend-project/small_eod/collections/tests.py
@@ -5,9 +5,11 @@ from django.urls import reverse
 from ..generic.tests import ReadOnlyViewSetMixin
 from ..users.factories import UserFactory
 
+
 class NoteViewSetTestCase(ReadOnlyViewSetMixin, TestCase):
     basename = "collection-note"
     factory_class = NoteFactory
+
     def setUp(self):
         super().setUp()
         self.collection = CollectionFactory(query=str(self.obj.case.id))

--- a/backend-project/small_eod/dictionaries/tests.py
+++ b/backend-project/small_eod/dictionaries/tests.py
@@ -1,19 +1,19 @@
 from django.test import TestCase
 from .models import Feature
 from .serializers import DictionarySerializer
+
 # Create your tests here.
 class DictionarySerializerTestCase(TestCase):
     def test_save_nested_values(self):
-        serializer = DictionarySerializer(data={
-            "name": "Czyja sprawa",
-            "active": True,
-            "min_items": 1,
-            "max_items": 2,
-            "values": [
-                { "name": "SO-WP"},
-                { "name": "Klienci"},
-            ]
-        })
+        serializer = DictionarySerializer(
+            data={
+                "name": "Czyja sprawa",
+                "active": True,
+                "min_items": 1,
+                "max_items": 2,
+                "values": [{"name": "SO-WP"}, {"name": "Klienci"},],
+            }
+        )
         self.assertTrue(serializer.is_valid(), serializer.errors)
         dictionary = serializer.save()
         self.assertTrue(Feature.objects.count(), 2)

--- a/backend-project/small_eod/generic/tests.py
+++ b/backend-project/small_eod/generic/tests.py
@@ -19,7 +19,7 @@ class ReadOnlyViewSetMixin:
 
     def setUp(self):
         if not self.factory_class:
-            raise NotImplementedError('factory_class must be defined')
+            raise NotImplementedError("factory_class must be defined")
         self.obj = self.factory_class()
         self.user = getattr(self, "user", UserFactory(username="john"))
         self.client.login(username="john", password="pass")
@@ -29,13 +29,11 @@ class ReadOnlyViewSetMixin:
 
     def get_url(self, name, **kwargs):
         if not self.basename:
-            raise NotImplementedError('get_url must be overridden or basename defined')
+            raise NotImplementedError("get_url must be overridden or basename defined")
         return reverse("{}-{}".format(self.basename, name), kwargs=kwargs)
 
     def test_list_plain(self):
-        response = self.client.get(
-            self.get_url(name="list", **self.get_extra_kwargs())
-        )
+        response = self.client.get(self.get_url(name="list", **self.get_extra_kwargs()))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 1)
         self.validate_item(response.json()[0])
@@ -48,17 +46,18 @@ class ReadOnlyViewSetMixin:
         self.validate_item(response.json())
 
     def validate_item(self, item):
-        raise NotImplementedError('validate_item must be overridden')
+        raise NotImplementedError("validate_item must be overridden")
 
 
 class GenericViewSetMixin(ReadOnlyViewSetMixin):
     def get_ommited_fields(self):
         return self.serializer_class.Meta.read_only_fields
+
     def test_create_plain(self):
         response = self.client.post(
             self.get_url(name="list", **self.get_extra_kwargs()),
             data=self.get_create_data(),
-            content_type='application/json'
+            content_type="application/json",
         )
         self.assertEqual(response.status_code, 201)
         item = response.json()
@@ -67,7 +66,7 @@ class GenericViewSetMixin(ReadOnlyViewSetMixin):
 
     def get_create_data(self):
         if not self.serializer_class:
-            raise NotImplementedError('serializer_class must be defined')
+            raise NotImplementedError("serializer_class must be defined")
         data = self.serializer_class(self.obj).data
         for field in self.get_ommited_fields():
             del data[field]
@@ -87,21 +86,20 @@ class FactoryCreateObjectsMixin:
             count,
             self.MODEL.objects.all().count(),
             msg=f"Failed {msg} factory test - "
-                f"position: {count} "
-                f"model: {self.MODEL} "
-                f"factory: {self.FACTORY} "
-                f"object: {obj}"
+            f"position: {count} "
+            f"model: {self.MODEL} "
+            f"factory: {self.FACTORY} "
+            f"object: {obj}",
         )
 
-    @tag('FactoryCreateObjectsMixin')
+    @tag("FactoryCreateObjectsMixin")
     def test_factories_simple(self):
-        self._test_factory_object(msg='simple', count=1)
+        self._test_factory_object(msg="simple", count=1)
 
-    @tag('FactoryCreateObjectsMixin')
+    @tag("FactoryCreateObjectsMixin")
     def test_factories_many(self):
         for x in range(1, self.FACTORY_COUNT):
-            self._test_factory_object(msg='many', count=x)
-
+            self._test_factory_object(msg="many", count=x)
 
     def test_print_to_console(self):
         """
@@ -113,7 +111,6 @@ class FactoryCreateObjectsMixin:
 
 
 class ExactLengthsValidatorTestCase(TestCase):
-
     def test_validator_message(self):
         """
         Validator returns corrrect error message.
@@ -124,7 +121,7 @@ class ExactLengthsValidatorTestCase(TestCase):
             validator("12")
 
         self.assertIn(
-            'Ensure this value has length of any [10, 14, 566, 1] (it has 2).',
+            "Ensure this value has length of any [10, 14, 566, 1] (it has 2).",
             err.exception,
         )
 
@@ -136,13 +133,18 @@ class ExactLengthsValidatorTestCase(TestCase):
         validator = ExactLengthsValidator([10, 14])
 
         # valid values
-        chars_10 = "1111111111"; self.assertEqual(len(chars_10), 10)
-        chars_14 = "11111111111111"; self.assertEqual(len(chars_14), 14)
+        chars_10 = "1111111111"
+        self.assertEqual(len(chars_10), 10)
+        chars_14 = "11111111111111"
+        self.assertEqual(len(chars_14), 14)
 
         # invalid values
-        chars_9 = "111111111"; self.assertEqual(len(chars_9), 9)
-        chars_12 = "111111111111"; self.assertEqual(len(chars_12), 12)
-        chars_15 = "111111111111111"; self.assertEqual(len(chars_15), 15)
+        chars_9 = "111111111"
+        self.assertEqual(len(chars_9), 9)
+        chars_12 = "111111111111"
+        self.assertEqual(len(chars_12), 12)
+        chars_15 = "111111111111111"
+        self.assertEqual(len(chars_15), 15)
 
         # valid test
         validator(chars_10)

--- a/backend-project/small_eod/institutions/tests.py
+++ b/backend-project/small_eod/institutions/tests.py
@@ -42,23 +42,26 @@ class ExternalIdentifierValidatorsTestCase(TestCase):
         """
         `nip` accepts only digits.
         """
-        f = modelform_factory(ExternalIdentifier, fields=('nip',))
+        f = modelform_factory(ExternalIdentifier, fields=("nip",))
 
-        form = f(data=dict(nip='abc'))
+        form = f(data=dict(nip="abc"))
         self.assertFalse(form.is_valid())
 
-        form = f(data=dict(nip='9999999999'))
+        form = f(data=dict(nip="9999999999"))
         self.assertTrue(form.is_valid())
 
     def test_nip_length(self):
         """
         `nip` accepts length of 10 only.
         """
-        f = modelform_factory(ExternalIdentifier, fields=('nip',))
+        f = modelform_factory(ExternalIdentifier, fields=("nip",))
 
-        chars_9 = '111111111'; self.assertEqual(len(chars_9), 9)
-        chars_10 = '1111111111'; self.assertEqual(len(chars_10), 10)
-        chars_11 = '11111111111'; self.assertEqual(len(chars_11), 11)
+        chars_9 = "111111111"
+        self.assertEqual(len(chars_9), 9)
+        chars_10 = "1111111111"
+        self.assertEqual(len(chars_10), 10)
+        chars_11 = "11111111111"
+        self.assertEqual(len(chars_11), 11)
 
         form = f(data=dict(nip=chars_9))
         self.assertFalse(form.is_valid())
@@ -73,25 +76,28 @@ class ExternalIdentifierValidatorsTestCase(TestCase):
         """
         `regon` accepts only digits.
         """
-        f = modelform_factory(ExternalIdentifier, fields=('regon',))
+        f = modelform_factory(ExternalIdentifier, fields=("regon",))
 
-        form = f(data=dict(regon='abc'))
+        form = f(data=dict(regon="abc"))
         self.assertFalse(form.is_valid())
 
-        form = f(data=dict(regon='9999999999'))
+        form = f(data=dict(regon="9999999999"))
         self.assertTrue(form.is_valid())
-
 
     def test_regon_length(self):
         """
         `regon` accepts length of 10 or 14 only.
         """
-        f = modelform_factory(ExternalIdentifier, fields=('regon',))
+        f = modelform_factory(ExternalIdentifier, fields=("regon",))
 
-        chars_9 = '111111111'; self.assertEqual(len(chars_9), 9)
-        chars_10 = '1111111111'; self.assertEqual(len(chars_10), 10)
-        chars_11 = '11111111111'; self.assertEqual(len(chars_11), 11)
-        chars_14 = '11111111111111'; self.assertEqual(len(chars_14), 14)
+        chars_9 = "111111111"
+        self.assertEqual(len(chars_9), 9)
+        chars_10 = "1111111111"
+        self.assertEqual(len(chars_10), 10)
+        chars_11 = "11111111111"
+        self.assertEqual(len(chars_11), 11)
+        chars_14 = "11111111111111"
+        self.assertEqual(len(chars_14), 14)
 
         form = f(data=dict(regon=chars_9))
         self.assertFalse(form.is_valid())

--- a/backend-project/small_eod/tags/tests.py
+++ b/backend-project/small_eod/tags/tests.py
@@ -16,7 +16,6 @@ class TagNamespaceFactoryTestCase(FactoryCreateObjectsMixin, TestCase):
 
 
 class TagsTestCase(TestCase):
-
     def test_prefix(self):
         """
         `Tag` can be matched by `TagNamespace.prefix`.


### PR DESCRIPTION
Nie rozumiem dlaczego testy zostały wykluczone z formatowania, chociaż jest to kod podobnie często czytany jak pozostały kod aplikacji,a formatowanie ma na celu poprawić czytelność kodu dla ludzi.