### PR TITLE
Reduce lint configuration

### DIFF
--- a/backend-project/config/settings/base.py
+++ b/backend-project/config/settings/base.py
@@ -97,11 +97,11 @@ DATABASES = {"default": env.db()}
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
     },
-    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",},
-    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},
-    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
 # Internationalization
@@ -133,7 +133,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],
-    "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated",],
+    "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_RENDERER_CLASSES": (
         "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
         "djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer",

--- a/backend-project/config/settings/development.py
+++ b/backend-project/config/settings/development.py
@@ -6,7 +6,7 @@ TEMPLATES[0]["OPTIONS"]["debug"] = True
 
 INSTALLED_APPS += ["debug_toolbar", "django_extensions"]
 
-MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware",] + MIDDLEWARE
+MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE
 
 INTERNAL_IPS = [
     "127.0.0.1",

--- a/backend-project/setup.cfg
+++ b/backend-project/setup.cfg
@@ -1,11 +1,7 @@
 [flake8]
 max-line-length = 88
-extend-ignore = E203,E231
-exclude = */tests/* */tests.py,*/migrations/*,./bower_components/*,./node_modules/*
+extend-ignore = E203
+exclude = */migrations/*,./bower_components/*,./node_modules/*
 max-complexity = 10
 per-file-ignores =
     ./backend-project/config/settings/*.py: F405,E501,W391
-    *.py: F401,W391
-
-# F401 unused import
-# W391 blank line at end of file

--- a/backend-project/small_eod/cases/tests.py
+++ b/backend-project/small_eod/cases/tests.py
@@ -14,8 +14,6 @@ from ..tags.factories import TagFactory
 from ..tags.models import Tag
 from ..users.factories import UserFactory
 from ..users.serializers import UserSerializer
-from ..generic.tests import GenericViewSetMixin
-from django.urls import reverse
 from rest_framework.test import APIRequestFactory, force_authenticate
 from ..notes.factories import NoteFactory
 
@@ -103,7 +101,7 @@ class CaseCountSerializerTestCase(TestCase):
         features = FeatureFactory.create_batch(size=5, dictionary=dictionary)
         serializer = CaseCountSerializer(
             data=self.get_default_data(
-                {"feature": [x.id for x in features], "tag": [],}
+                {"feature": [x.id for x in features], "tag": []}
             ),
             context={"request": self.request},
         )
@@ -161,7 +159,7 @@ class UserViewSetMixin(ReadOnlyViewSetMixin):
 
     def setUp(self):
         super().setUp()
-        field_dict = {self.__class__.user_type: [self.obj.pk,]}
+        field_dict = {self.__class__.user_type: [self.obj.pk]}
         self.case = CaseFactory(**field_dict)
 
     def get_extra_kwargs(self):

--- a/backend-project/small_eod/channels/serializers.py
+++ b/backend-project/small_eod/channels/serializers.py
@@ -1,6 +1,4 @@
 from rest_framework import serializers
-from itertools import groupby
-from operator import attrgetter
 from .models import Channel
 
 

--- a/backend-project/small_eod/collections/serializers.py
+++ b/backend-project/small_eod/collections/serializers.py
@@ -1,6 +1,3 @@
-from rest_framework import serializers
-from itertools import groupby
-from operator import attrgetter
 from .models import Collection
 from ..generic.serializers import UserLogModelSerializer
 

--- a/backend-project/small_eod/collections/urls.py
+++ b/backend-project/small_eod/collections/urls.py
@@ -7,7 +7,7 @@ from .views import (
     NoteViewSet,
 )
 
-from django.urls import path, re_path, include
+from django.urls import path, include
 
 router = routers.SimpleRouter()
 router.register("collections", CollectionViewSet)

--- a/backend-project/small_eod/dictionaries/serializers.py
+++ b/backend-project/small_eod/dictionaries/serializers.py
@@ -1,5 +1,3 @@
-from rest_framework import serializers
-
 from .models import Dictionary, Feature
 from ..generic.serializers import UserLogModelSerializer
 

--- a/backend-project/small_eod/dictionaries/tests.py
+++ b/backend-project/small_eod/dictionaries/tests.py
@@ -40,7 +40,7 @@ class DictionarySerializerTestCase(TestCase):
                 "active": True,
                 "min_items": 1,
                 "max_items": 2,
-                "values": [{"name": "SO-WP"}, {"name": "Klienci"},],
+                "values": [{"name": "SO-WP"}, {"name": "Klienci"}],
             },
             context={"request": self.request},
         )

--- a/backend-project/small_eod/dictionaries/urls.py
+++ b/backend-project/small_eod/dictionaries/urls.py
@@ -1,1 +1,0 @@
-from .views import DictionaryViewSet

--- a/backend-project/small_eod/events/serializers.py
+++ b/backend-project/small_eod/events/serializers.py
@@ -1,6 +1,3 @@
-from rest_framework import serializers
-from itertools import groupby
-from operator import attrgetter
 from .models import Event
 from ..generic.serializers import UserLogModelSerializer
 

--- a/backend-project/small_eod/files/serializers.py
+++ b/backend-project/small_eod/files/serializers.py
@@ -1,6 +1,4 @@
 from rest_framework import serializers
-from itertools import groupby
-from operator import attrgetter
 from .models import File
 
 

--- a/backend-project/small_eod/files/tests.py
+++ b/backend-project/small_eod/files/tests.py
@@ -1,3 +1,0 @@
-# from django.test import TestCase
-
-# Create your tests here.

--- a/backend-project/small_eod/generic/factories.py
+++ b/backend-project/small_eod/generic/factories.py
@@ -67,7 +67,7 @@ class FuzzyRegon(factory.fuzzy.BaseFuzzyAttribute):
         self.chars_14 = factory.fuzzy.FuzzyText(length=14, chars=string.digits)
 
     def fuzz(self):
-        return factory.random.randgen.choice([self.chars_10, self.chars_14,]).fuzz()
+        return factory.random.randgen.choice([self.chars_10, self.chars_14]).fuzz()
 
 
 class RGBColorFuzzyAttribute(factory.fuzzy.BaseFuzzyAttribute):

--- a/backend-project/small_eod/generic/tests.py
+++ b/backend-project/small_eod/generic/tests.py
@@ -2,7 +2,6 @@ from typing import Type
 
 from django.core.validators import ValidationError
 from django.db.models import Model
-from django.forms import model_to_dict
 from django.test import TestCase
 from django.test import tag
 from django.urls import reverse
@@ -111,6 +110,7 @@ class FactoryCreateObjectsMixin:
     #     Just making sure that frontend has the right data
     #     to work with.
     #     """
+    #     from django.forms import model_to_dict
     #     print(f"\n{model_to_dict(self.create_factory())}")
 
 

--- a/backend-project/small_eod/institutions/models.py
+++ b/backend-project/small_eod/institutions/models.py
@@ -21,7 +21,7 @@ class ExternalIdentifier(models.Model):
 
     nip = models.CharField(
         max_length=10,
-        validators=[ExactLengthsValidator([10]), validators.RegexValidator("[0-9]*$"),],
+        validators=[ExactLengthsValidator([10]), validators.RegexValidator("[0-9]*$")],
     )
 
     regon = models.CharField(

--- a/backend-project/small_eod/institutions/views.py
+++ b/backend-project/small_eod/institutions/views.py
@@ -1,7 +1,7 @@
 from rest_framework import viewsets
 
-from .serializers import AddressDataSerializer, InstitutionSerializer
-from .models import AddressData, Institution
+from .serializers import InstitutionSerializer
+from .models import Institution
 
 
 class InstitutionViewSet(viewsets.ModelViewSet):

--- a/backend-project/small_eod/letters/serializers.py
+++ b/backend-project/small_eod/letters/serializers.py
@@ -1,6 +1,4 @@
 from rest_framework import serializers
-from itertools import groupby
-from operator import attrgetter
 from .models import Letter, Description
 from ..generic.serializers import UserLogModelSerializer
 

--- a/backend-project/small_eod/notes/serializers.py
+++ b/backend-project/small_eod/notes/serializers.py
@@ -1,6 +1,3 @@
-from rest_framework import serializers
-from itertools import groupby
-from operator import attrgetter
 from .models import Note
 from ..generic.serializers import UserLogModelSerializer
 

--- a/backend-project/small_eod/tags/serializers.py
+++ b/backend-project/small_eod/tags/serializers.py
@@ -1,6 +1,4 @@
 from rest_framework import serializers
-from itertools import groupby
-from operator import attrgetter
 from .models import Tag
 
 


### PR DESCRIPTION
Nadmiarowe importy są groźne. Sprzyjają cyklicznym importom. Do poczytania na temat sposobu działania importów w Python: https://stackoverflow.com/questions/744373/circular-or-cyclic-imports-in-python