### PR TITLE
Proxy for frontend mock data

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -7,24 +7,31 @@ upstream frontend {
 }
 
 server {
+  # temporary mock while we don't have login functionality in backend
+  # or frontend functionality provided by bootstrapped Ant Design is not yet
+  # removed
+  location ~ ^/api/(notices|auth_routes|currentUser|users|login/account|register|500|404|403|401|login/captcha) {
+    rewrite ^/api/(.*) /api/$1 break;
+    proxy_pass http://frontend;
+  }
 
-    location /static/ {
-        autoindex off;
-        alias /static/;
-    }
+  location /static/ {
+    autoindex off;
+    alias /static/;
+  }
 
-    location /api {
-        proxy_pass http://backend/api;
-    }
+  location /api {
+    proxy_pass http://backend/api;
+  }
 
-    location /admin {
-        proxy_pass http://backend/admin;
-    }
+  location /admin {
+    proxy_pass http://backend/admin;
+  }
 
-    location / {
-        proxy_pass http://frontend/;
-    }
+  location / {
+    proxy_pass http://frontend/;
+  }
 
-    listen 8000;
-    server_name localhost;
+  listen 8000;
+  server_name localhost;
 }


### PR DESCRIPTION
Ant Desing provides mocked data for its bootstrapped application.

Working on standalone frontend project (without proxy in Nginx) causes all HTTP requests to be handled by Ant Desing/umijs internally (and therefore it serves mocked data).

After the introduction of Nginx and putting Ant Desing developer server behind it all request for mocked data are going through Nginx and because it redirect all `/api` calls to Django backend, we were not able to login to frontend. That pull request resolves that issue.

Be aware, that's only a temporary solution to ease development. While we rewrite frontend screens (from these bootstrapped to ones that we actually need) and integrate them with genuine Django backend we will gradually remove these redirects.

### Ho to test
* `make start`
* wait for a moment, as it takes a while for frontend to start developer server (in the meanwhile you can `make logs` and look for these lines, at they mean that frontend was build and is available:
```
frontend_1  | ✔ Webpack
frontend_1  |   Compiled successfully in 46.82s
frontend_1  | 
frontend_1  | Starting the development server...
frontend_1  | 
frontend_1  |  DONE  Compiled successfully in 46825ms8:47:35 AM
frontend_1  | 
frontend_1  | 
frontend_1  |   App running at:
frontend_1  |   - Local:   http://localhost:8000/ (copy to clipboard failed)
frontend_1  |   - Network: http://172.26.0.2:8000/
frontend_1  | 
```
* go to http://localhost:8000
* login using user: `admin` and password `ant.design`
* see that stuff is served

### Side notes
I also make indentations in `nginx.conf` consistence (2 spaces indentation).