### PR TITLE
Prestart db before mysql in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: all test clean docs
 
-start:
+start: wait_mysql wait_minio
 	docker-compose up -d
-
+	
 stop:
 	docker-compose stop
 


### PR DESCRIPTION
Let's try this approach. Alternatively, you'll be able to start using the healthcheck from the docker if it turns out to be ineffective.