### PR TITLE
Usunięcie niektórych użyć typu any

### DIFF
--- a/frontend-project/src/components/Table/CaseName.tsx
+++ b/frontend-project/src/components/Table/CaseName.tsx
@@ -19,4 +19,4 @@ const CaseName: FC<CaseNameProps> = ({ id, cases, dispatch }) => {
   return <div>{oneCase ? oneCase.name : <Spin />}</div>;
 };
 
-export default connect(({ cases }: any) => ({ cases }))(CaseName);
+export default connect(({ cases }: CaseNameProps) => ({ cases }))(CaseName);

--- a/frontend-project/src/components/Table/ChannelName.tsx
+++ b/frontend-project/src/components/Table/ChannelName.tsx
@@ -17,4 +17,4 @@ const ChannelName: FC<ChannelNameProps> = ({ id, channels, dispatch }) => {
   const channel = channels.find(value => value.id === id);
   return <div>{channel ? channel.name : <Spin />}</div>;
 };
-export default connect(({ channels }: any) => ({ channels }))(ChannelName);
+export default connect(({ channels }: ChannelNameProps) => ({ channels }))(ChannelName);

--- a/frontend-project/src/components/Table/InstitutionName.tsx
+++ b/frontend-project/src/components/Table/InstitutionName.tsx
@@ -18,4 +18,6 @@ const InstitutionName: FC<InstitutionNameProps> = ({ id, institutions, dispatch 
   return <div>{institution ? institution.name : <Spin />}</div>;
 };
 
-export default connect(({ institutions }: any) => ({ institutions }))(InstitutionName);
+export default connect(({ institutions }: InstitutionNameProps) => ({ institutions }))(
+  InstitutionName,
+);

--- a/frontend-project/src/models/setting.ts
+++ b/frontend-project/src/models/setting.ts
@@ -1,10 +1,11 @@
+import { Reducer } from 'redux';
 import defaultSettings, { DefaultSettings } from '../../config/defaultSettings';
 
 export interface SettingModelType {
   namespace: 'settings';
   state: DefaultSettings;
   reducers: {
-    changeSetting: any;
+    changeSetting: Reducer;
   };
 }
 

--- a/frontend-project/src/models/user.ts
+++ b/frontend-project/src/models/user.ts
@@ -1,4 +1,6 @@
 import { queryCurrent, query as queryUsers } from '@/services/user';
+import { Effect } from 'dva';
+import { Reducer } from 'redux';
 
 export interface CurrentUser {
   avatar?: string;
@@ -22,12 +24,12 @@ export interface UserModelType {
   namespace: 'user';
   state: UserModelState;
   effects: {
-    fetch: any;
-    fetchCurrent: any;
+    fetch: Effect;
+    fetchCurrent: Effect;
   };
   reducers: {
-    saveCurrentUser: any;
-    changeNotifyCount: any;
+    saveCurrentUser: Reducer;
+    changeNotifyCount: Reducer;
   };
 }
 

--- a/frontend-project/src/pages/cases/new/index.tsx
+++ b/frontend-project/src/pages/cases/new/index.tsx
@@ -206,6 +206,8 @@ const CasesNewForm: FunctionComponent<CasesNewFormProps> = ({
   );
 };
 
-export default connect(({ tags, users, institutions }: any) => ({ tags, users, institutions }))(
-  CasesNewForm,
-);
+export default connect(({ tags, users, institutions }: CasesNewFormProps) => ({
+  tags,
+  users,
+  institutions,
+}))(CasesNewForm);


### PR DESCRIPTION
Typ any generalnie powinien być unikany jak tylko się da. Przeważnie, nawet gdy nie znamy pełnej struktury obiektu, który przyjmujemy, zamiast niego da się użyć [interfejsów](https://www.typescriptlang.org/docs/handbook/interfaces.html), [typów generycznych](https://www.typescriptlang.org/docs/handbook/generics.html) lub ewentualnie typu unknown