### PR TITLE
Refaktoryzacja modeli frontendowych

### DIFF
--- a/frontend-project/src/models/cases.ts
+++ b/frontend-project/src/models/cases.ts
@@ -14,6 +14,7 @@ export interface CaseModelType {
     saveOne: Reducer<CaseModelState, AnyAction>;
   };
 }
+
 const defaultCasesState: CaseModelState = [];
 
 const CasesModel: CaseModelType = {

--- a/frontend-project/src/models/cases.ts
+++ b/frontend-project/src/models/cases.ts
@@ -17,17 +17,19 @@ export interface Case {
   modifiedOn: string;
 }
 
+export type CaseModelState = Case[];
+
 export interface CaseModelType {
   namespace: string;
-  state: Case[];
+  state: CaseModelState;
   effects: {
     fetchOne: Effect;
   };
   reducers: {
-    saveOne: Reducer<Case[], AnyAction>;
+    saveOne: Reducer<CaseModelState, AnyAction>;
   };
 }
-const defaultCasesState: Case[] = [];
+const defaultCasesState: CaseModelState = [];
 
 const CasesModel: CaseModelType = {
   namespace: 'cases',

--- a/frontend-project/src/models/cases.ts
+++ b/frontend-project/src/models/cases.ts
@@ -1,21 +1,6 @@
-import { fetchOne } from '@/services/cases';
+import { fetchOne, Case } from '@/services/cases';
 import { Effect, EffectsCommandMap } from 'dva';
 import { AnyAction, Reducer } from 'redux';
-
-export interface Case {
-  name: string;
-  auditedInstitutions: number[];
-  comment: string;
-  tags: string[];
-  responsible_users: number[];
-  notified_users: number[];
-  featureoptions: number[];
-  createdBy: number;
-  createdOn: string;
-  id: number;
-  modifiedBy: number;
-  modifiedOn: string;
-}
 
 export type CaseModelState = Case[];
 

--- a/frontend-project/src/models/channels.ts
+++ b/frontend-project/src/models/channels.ts
@@ -1,26 +1,30 @@
 import { fetchPage, fetchOne, Channel } from '@/services/channels';
-import { Effect, EffectsCommandMap } from 'dva';
+import { Effect } from 'dva';
 import { AnyAction, Reducer } from 'redux';
+import { CaseModelState } from './cases';
+
+export type ChannelModelState = Channel[];
 
 export interface ChannelModelType {
   namespace: string;
-  state: Channel[];
+  state: ChannelModelState;
   effects: {
     fetchPage: Effect;
     fetchOne: Effect;
   };
   reducers: {
-    savePage: Reducer<Channel[], AnyAction>;
-    saveOne: Reducer<Channel[], AnyAction>;
+    savePage: Reducer<ChannelModelState, AnyAction>;
+    saveOne: Reducer<CaseModelState, AnyAction>;
   };
 }
-const defaultChannelsState: Channel[] = [];
+
+const defaultChannelsState: ChannelModelState = [];
 
 const ChannelsModel: ChannelModelType = {
   namespace: 'channels',
   state: defaultChannelsState,
   effects: {
-    *fetchPage({ payload }: AnyAction, { call, put }: EffectsCommandMap) {
+    *fetchPage({ payload }, { call, put }) {
       const response = yield call(fetchPage, payload);
       yield put({
         type: 'savePage',
@@ -28,7 +32,7 @@ const ChannelsModel: ChannelModelType = {
       });
       return response;
     },
-    *fetchOne({ payload }: AnyAction, { call, put }: EffectsCommandMap) {
+    *fetchOne({ payload }, { call, put }) {
       const response = yield call(fetchOne, payload);
       yield put({
         type: 'saveOne',

--- a/frontend-project/src/models/institutions.ts
+++ b/frontend-project/src/models/institutions.ts
@@ -1,6 +1,8 @@
 import { fetchAll, fetchOne } from '@/services/institutions';
-import { Effect, EffectsCommandMap } from 'dva';
+import { Effect } from 'dva';
 import { AnyAction, Reducer } from 'redux';
+
+export type InstitutionsModelState = Institution[];
 
 export interface Institution {
   id: number;
@@ -16,32 +18,33 @@ export interface Institution {
   regon?: number;
 }
 
+const defaultInstitutionsState: InstitutionsModelState = [];
+
 export interface InstitutionModelType {
   namespace: string;
-  state: Institution[];
+  state: InstitutionsModelState;
   effects: {
     fetchAll: Effect;
     fetchOne: Effect;
   };
   reducers: {
-    saveAll: Reducer<Institution[], AnyAction>;
-    saveOne: Reducer<Institution[], AnyAction>;
+    saveAll: Reducer<InstitutionsModelState, AnyAction>;
+    saveOne: Reducer<InstitutionsModelState, AnyAction>;
   };
 }
-const defaultInstitutionsState: Institution[] = [];
 
 const InstitutionsModel: InstitutionModelType = {
   namespace: 'institutions',
   state: defaultInstitutionsState,
   effects: {
-    *fetchAll(_: AnyAction, { call, put }: EffectsCommandMap) {
+    *fetchAll(_, { call, put }) {
       const response = yield call(fetchAll);
       yield put({
         type: 'saveAll',
         payload: response,
       });
     },
-    *fetchOne({ payload }: AnyAction, { call, put }: EffectsCommandMap) {
+    *fetchOne({ payload }, { call, put }) {
       const response = yield call(fetchOne, payload);
       yield put({
         type: 'saveOne',

--- a/frontend-project/src/models/login.ts
+++ b/frontend-project/src/models/login.ts
@@ -23,6 +23,7 @@ export interface LoginModelType {
     changeLoginStatus: Reducer<LoginModelState>;
   };
 }
+
 const Model: LoginModelType = {
   namespace: 'login',
 

--- a/frontend-project/src/models/tags.ts
+++ b/frontend-project/src/models/tags.ts
@@ -1,6 +1,8 @@
 import { fetchAll, fetchPage, Tag } from '@/services/tags';
-import { Effect, EffectsCommandMap } from 'dva';
-import { AnyAction, Reducer } from 'redux';
+import { Effect } from 'dva';
+import { Reducer } from 'redux';
+
+export type TagDefaultState = Tag[];
 
 export interface TagModelType {
   namespace: string;
@@ -10,24 +12,24 @@ export interface TagModelType {
     fetchPage: Effect;
   };
   reducers: {
-    saveAll: Reducer<Tag[], AnyAction>;
-    savePage: Reducer<Tag[], AnyAction>;
+    saveAll: Reducer<TagDefaultState>;
+    savePage: Reducer<TagDefaultState>;
   };
 }
-const defaultTagsState: Tag[] = [];
+const defaultTagsState: TagDefaultState = [];
 
 const TagsModel: TagModelType = {
   namespace: 'tags',
   state: defaultTagsState,
   effects: {
-    *fetchAll(_: AnyAction, { call, put }: EffectsCommandMap) {
+    *fetchAll(_, { call, put }) {
       const response = yield call(fetchAll);
       yield put({
         type: 'saveAll',
         payload: response,
       });
     },
-    *fetchPage({ payload }: AnyAction, { call, put }: EffectsCommandMap) {
+    *fetchPage({ payload }, { call, put }) {
       const response = yield call(fetchPage, payload);
       yield put({
         type: 'savePage',

--- a/frontend-project/src/models/user.ts
+++ b/frontend-project/src/models/user.ts
@@ -28,8 +28,8 @@ export interface UserModelType {
     fetchCurrent: Effect;
   };
   reducers: {
-    saveCurrentUser: Reducer;
-    changeNotifyCount: Reducer;
+    saveCurrentUser: Reducer<UserModelState>;
+    changeNotifyCount: Reducer<UserModelState>;
   };
 }
 

--- a/frontend-project/src/models/users.ts
+++ b/frontend-project/src/models/users.ts
@@ -1,6 +1,5 @@
 import { fetchAll } from '@/services/users';
-import { Effect, EffectsCommandMap } from 'dva';
-import { AnyAction } from 'redux';
+import { Effect } from 'dva';
 import { Reducer } from 'react';
 
 export interface User {
@@ -11,27 +10,30 @@ export interface User {
   id: number;
 }
 
-export interface Payload {
+export type UsersModelState = User[];
+
+export interface SaveAllUsersPayload {
   payload: { results: User[] };
 }
 
 export interface UsersModelType {
   namespace: string;
-  state: User[];
+  state: UsersModelState;
   effects: {
     fetchAll: Effect;
   };
   reducers: {
-    saveAll: Reducer<User[], Payload>;
+    saveAll: Reducer<UsersModelState, SaveAllUsersPayload>;
   };
 }
+
 const defaultUsersState: User[] = [];
 
 const UsersModel: UsersModelType = {
   namespace: 'users',
   state: defaultUsersState,
   effects: {
-    *fetchAll(_: AnyAction, { call, put }: EffectsCommandMap) {
+    *fetchAll(_, { call, put }) {
       const response = yield call(fetchAll);
       yield put({
         type: 'saveAll',


### PR DESCRIPTION
Usunąłem nieużywane intefejsy, dodałem interfejs/typ dla każdego state, oraz usunąłem typowania przeprowadzone więcej niż raz 

Nie przeprowadziłem do końca refaktoryzacji pliku institutions, który zawiera interfejs, który najprawdopodobniej jest zdublowany

IDE mi podpowiada, że jeden jest autorstwa @mateuszmagulski:
https://github.com/watchdogpolska/small_eod/blob/3389118c33f4ae98d94f73269bacc83dc5a86c78/frontend-project/src/services/institutions.ts#L4-L22

a drugi @Loczi94:
https://github.com/watchdogpolska/small_eod/blob/3389118c33f4ae98d94f73269bacc83dc5a86c78/frontend-project/src/models/institutions.ts#L5-L17

i nie są one do końca zgodne
