### PR TITLE
Drop nzh from front-end

### DIFF
--- a/frontend-project/package.json
+++ b/frontend-project/package.json
@@ -63,7 +63,6 @@
     "lodash.isequal": "^4.5.0",
     "moment": "^2.24.0",
     "numeral": "^2.0.6",
-    "nzh": "^1.0.3",
     "omit.js": "^1.0.2",
     "path-to-regexp": "2.4.0",
     "prop-types": "^15.5.10",

--- a/frontend-project/yarn.lock
+++ b/frontend-project/yarn.lock
@@ -13015,11 +13015,6 @@ nwsapi@^2.0.7, nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
-nzh@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/nzh/-/nzh-1.0.4.tgz#bded5492cd7148fa5fe1c809fa61932a899769c5"
-  integrity sha512-A1qQSJTctuzmNlAAqV8AcvcOcsGn0iBbRn2Jhw4KkEFCDkXd5YV7SkfPQ6fw6fGVtJzo6++sGS/W1JZizRmCNQ==
-
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -17213,7 +17208,6 @@ slice-ansi@^2.1.0:
 
 "small_eod_client@https://github.com/watchdogpolska/small-eod-sdk-javascript.git#13e88e0173fc6716f64624f254402521b8929e2a":
   version "1.0.4"
-  uid "13e88e0173fc6716f64624f254402521b8929e2a"
   resolved "https://github.com/watchdogpolska/small-eod-sdk-javascript.git#13e88e0173fc6716f64624f254402521b8929e2a"
   dependencies:
     superagent "5.1.0"


### PR DESCRIPTION
i18n library oriended in chinese. See https://www.npmjs.com/package/nzh 

We don't target i18n for zh.