### PR TITLE
Auto-pin Docker digest & auto-update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "config:base",
+    "default:automergeDigest"
+  ],
+  "docker": {
+    "pinDigests": true
+  }
+}


### PR DESCRIPTION
Pamiętam, że kiedyś odmówiłem przypinania obrazu Dockerowego z powodu nakładu pracy. Jednakże automatyczne mergowanie wydaje mi się rozsądnym kompromisem, ponieważ nie wymaga to pracy człowieka, a pozostawia ślad po zmianie. Dodatkowo wyzwala to bypass cache, co sprawi, że cache nie będzie zaskakiwał subtelnymi różnicami.