### PR TITLE
Disable Vercel comments

### DIFF
--- a/frontend-project/vercel.json
+++ b/frontend-project/vercel.json
@@ -8,5 +8,8 @@
     },
     { "handle": "filesystem" },
     { "src": "/.*", "dest": "/index.html" }
-  ]
+  ],
+  "github": {
+    "silent": true
+  }
 }


### PR DESCRIPTION
> When set to true, Vercel for GitHub will stop commenting on pull requests and commits.

https://vercel.com/docs/configuration

Links to preview is still available as deployments.