### PR TITLE
frontend: Increment token refresh frequency

### DIFF
--- a/frontend-project/src/layouts/BasicLayout.tsx
+++ b/frontend-project/src/layouts/BasicLayout.tsx
@@ -69,7 +69,7 @@ const BasicLayout: FC<BasicLayoutProps> = props => {
   useEffect(() => {
     if (auth.isLoggedIn()) {
       auth.refreshToken();
-      window.setInterval(() => auth.refreshToken(), (auth.expires() * 1000) / 3 / 4);
+      window.setInterval(() => auth.refreshToken(), ((auth.expires() * 1000) / 3) * 2);
     }
   }, []);
 


### PR DESCRIPTION
Obecnie back-end daje token z `expiresIn: 300`. Jeżeli dobrze odczytuje kod w tym przypadku ten token będzie odnawiany co 25 sekund. Co więcej, każda karta będzie wykonywać to niezależnie, chociaż współdzielą one informacje o tokenie. W efekcie przy 10 kartach możemy mieć wymianę tokenu co średnio 2,5 sekudny. Zupełnie zbędny ruch. Myślę, że w 2/3 czasu jest dość bezpiecznie. 