### PR TITLE
Autocomplete fixes 2

### DIFF
--- a/backend-project/small_eod/autocomplete/serializers.py
+++ b/backend-project/small_eod/autocomplete/serializers.py
@@ -6,7 +6,7 @@ from ..channels.models import Channel
 from ..events.models import Event
 from ..features.models import Feature, FeatureOption
 from ..institutions.models import Institution
-from ..letters.models import DocumentType
+from ..letters.models import DocumentType, ReferenceNumber
 from ..tags.models import Tag
 from ..users.models import User
 
@@ -32,6 +32,12 @@ class ChannelAutocompleteSerializer(serializers.ModelSerializer):
 class DocumentTypeAutocompleteSerializer(serializers.ModelSerializer):
     class Meta:
         model = DocumentType
+        fields = ["id", "name"]
+
+
+class ReferenceNumberAutocompleteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ReferenceNumber
         fields = ["id", "name"]
 
 

--- a/backend-project/small_eod/autocomplete/tests/test_serializers.py
+++ b/backend-project/small_eod/autocomplete/tests/test_serializers.py
@@ -16,11 +16,11 @@ from ..serializers import (
     CaseAutocompleteSerializer,
     ChannelAutocompleteSerializer,
     DocumentTypeAutocompleteSerializer,
-    ReferenceNumberAutocompleteSerializer,
     EventAutocompleteSerializer,
     FeatureAutocompleteSerializer,
     FeatureOptionAutocompleteSerializer,
     InstitutionAutocompleteSerializer,
+    ReferenceNumberAutocompleteSerializer,
     TagAutocompleteSerializer,
     UserAutocompleteSerializer,
 )

--- a/backend-project/small_eod/autocomplete/tests/test_serializers.py
+++ b/backend-project/small_eod/autocomplete/tests/test_serializers.py
@@ -8,7 +8,7 @@ from ...features.factories import FeatureFactory, FeatureOptionFactory
 from ...generic.mixins import AuthRequiredMixin
 from ...generic.tests.test_serializers import ResourceSerializerMixin
 from ...institutions.factories import InstitutionFactory
-from ...letters.factories import DocumentTypeFactory
+from ...letters.factories import DocumentTypeFactory, ReferenceNumberFactory
 from ...tags.factories import TagFactory
 from ...users.factories import UserFactory
 from ..serializers import (
@@ -16,6 +16,7 @@ from ..serializers import (
     CaseAutocompleteSerializer,
     ChannelAutocompleteSerializer,
     DocumentTypeAutocompleteSerializer,
+    ReferenceNumberAutocompleteSerializer,
     EventAutocompleteSerializer,
     FeatureAutocompleteSerializer,
     FeatureOptionAutocompleteSerializer,
@@ -51,6 +52,13 @@ class DocumentTypeAutocompleteSerializerTestCase(
 ):
     serializer_class = DocumentTypeAutocompleteSerializer
     factory_class = DocumentTypeFactory
+
+
+class ReferenceNumberAutocompleteSerializerTestCase(
+    ResourceSerializerMixin, AuthRequiredMixin, TestCase
+):
+    serializer_class = ReferenceNumberAutocompleteSerializer
+    factory_class = ReferenceNumberFactory
 
 
 class EventAutocompleteSerializerTestCase(

--- a/backend-project/small_eod/autocomplete/tests/test_views.py
+++ b/backend-project/small_eod/autocomplete/tests/test_views.py
@@ -7,7 +7,11 @@ from ...events.factories import EventFactory
 from ...features.factories import FeatureFactory, FeatureOptionFactory
 from ...generic.tests.test_views import ReadOnlyViewSetMixin
 from ...institutions.factories import InstitutionFactory
-from ...letters.factories import DocumentTypeFactory
+from ...letters.factories import (
+    DocumentTypeFactory,
+    ReferenceNumberFactory,
+    LetterFactory,
+)
 from ...search.tests.mixins import SearchQueryMixin
 from ...tags.factories import TagFactory
 from ...users.factories import UserFactory
@@ -53,6 +57,56 @@ class DocumentTypeAutocompleteViewSetTestCase(
     def validate_item(self, item):
         self.assertEqual(item["id"], self.obj.id)
         self.assertEqual(item["name"], self.obj.name)
+
+
+class ReferenceNumberAutocompleteViewSetTestCase(
+    ReadOnlyViewSetMixin, SearchQueryMixin, TestCase
+):
+    basename = "autocomplete_reference_number"
+    factory_class = ReferenceNumberFactory
+
+    def validate_item(self, item):
+        self.assertEqual(item["id"], self.obj.id)
+        self.assertEqual(item["name"], self.obj.name)
+
+    def test_suggests_related(self):
+        case = CaseFactory()
+
+        # `ReadOnlyViewSetMixin` creates a single instance in its `setUp` method.
+        # Resuse the object not to have dangling items.
+        reference_number_a = self.obj
+        reference_number_b = ReferenceNumberFactory(name="ref_b")
+        reference_number_c = ReferenceNumberFactory(name="ref_c")
+        LetterFactory(reference_number=reference_number_a, case=None)
+        LetterFactory(reference_number=reference_number_b, case=case)
+        LetterFactory(reference_number=reference_number_c, case=case)
+
+        # Match all - the related items should appear at the top.
+        # There's no guarantee on specific ordering of items. We only have guarantees
+        # that:
+        # 1. Both related and unrelated items appear in the result.
+        # 2. Related items appear before unrelated ones
+        resp = self.get_response_for_query("ref", case=case.id)
+        result_ids = [datum["id"] for datum in resp.data["results"]]
+
+        # Ad. 1
+        self.assertEqual(
+            set(result_ids),
+            {reference_number_a.id, reference_number_b.id, reference_number_c.id},
+        )
+
+        # Ad. 2.
+        self.assertEqual(
+            set(result_ids[:2]), {reference_number_b.id, reference_number_c.id}
+        )
+        self.assertEqual(result_ids[2], reference_number_a.id)
+
+        # Match a specific, non-related item.
+        # Related items should not be present.
+        resp = self.get_response_for_query(reference_number_a.name, case=case.id)
+        self.assertEqual(
+            [r["id"] for r in resp.data["results"]], [reference_number_a.id]
+        )
 
 
 class EventAutocompleteViewSetTestCase(
@@ -109,12 +163,12 @@ class InstitutionAutocompleteViewSetTestCase(
 
         # Match all - the related institution should appear at the top.
         resp = self.get_response_for_query("institution", case=case.id)
-        self.assertEqual(resp.data['results'][0]['id'], institution_b.id)
+        self.assertEqual(resp.data["results"][0]["id"], institution_b.id)
 
         # Match a specific, non-related item.
         # The related institution should not be present.
         resp = self.get_response_for_query("institution_a", case=case.id)
-        self.assertEqual([r['id'] for r in resp.data['results']], [institution_a.id])
+        self.assertEqual([r["id"] for r in resp.data["results"]], [institution_a.id])
 
 
 class TagAutocompleteViewSetTestCase(ReadOnlyViewSetMixin, SearchQueryMixin, TestCase):

--- a/backend-project/small_eod/autocomplete/tests/test_views.py
+++ b/backend-project/small_eod/autocomplete/tests/test_views.py
@@ -9,8 +9,8 @@ from ...generic.tests.test_views import ReadOnlyViewSetMixin
 from ...institutions.factories import InstitutionFactory
 from ...letters.factories import (
     DocumentTypeFactory,
-    ReferenceNumberFactory,
     LetterFactory,
+    ReferenceNumberFactory,
 )
 from ...search.tests.mixins import SearchQueryMixin
 from ...tags.factories import TagFactory

--- a/backend-project/small_eod/autocomplete/urls.py
+++ b/backend-project/small_eod/autocomplete/urls.py
@@ -6,11 +6,11 @@ from .views import (
     CaseAutocompleteViewSet,
     ChannelAutocompleteViewSet,
     DocumentTypeAutocompleteViewSet,
-    ReferenceNumberAutocompleteViewSet,
     EventAutocompleteViewSet,
     FeatureAutocompleteViewSet,
     FeatureOptionAutocompleteViewSet,
     InstitutionAutocompleteViewSet,
+    ReferenceNumberAutocompleteViewSet,
     TagAutocompleteViewSet,
     UserAutocompleteViewSet,
 )

--- a/backend-project/small_eod/autocomplete/urls.py
+++ b/backend-project/small_eod/autocomplete/urls.py
@@ -6,6 +6,7 @@ from .views import (
     CaseAutocompleteViewSet,
     ChannelAutocompleteViewSet,
     DocumentTypeAutocompleteViewSet,
+    ReferenceNumberAutocompleteViewSet,
     EventAutocompleteViewSet,
     FeatureAutocompleteViewSet,
     FeatureOptionAutocompleteViewSet,
@@ -24,6 +25,11 @@ router.register("cases", CaseAutocompleteViewSet, "autocomplete_case")
 router.register("channels", ChannelAutocompleteViewSet, "autocomplete_channel")
 router.register(
     "document_types", DocumentTypeAutocompleteViewSet, "autocomplete_document_type"
+)
+router.register(
+    "reference_numbers",
+    ReferenceNumberAutocompleteViewSet,
+    "autocomplete_reference_number",
 )
 router.register("events", EventAutocompleteViewSet, "autocomplete_event")
 router.register("features", FeatureAutocompleteViewSet, "autocomplete_feature")

--- a/backend-project/small_eod/autocomplete/views.py
+++ b/backend-project/small_eod/autocomplete/views.py
@@ -1,5 +1,5 @@
-from django_filters.rest_framework import DjangoFilterBackend
 from django.db import models
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
 
 from ..administrative_units.filterset import AdministrativeUnitFilterSet
@@ -15,7 +15,7 @@ from ..features.models import Feature, FeatureOption
 from ..institutions.filterset import InstitutionFilterSet
 from ..institutions.models import Institution
 from ..letters.filterset import DocumentTypeFilterSet, ReferenceNumberFilterSet
-from ..letters.models import DocumentType, ReferenceNumber, Letter
+from ..letters.models import DocumentType, Letter, ReferenceNumber
 from ..tags.filterset import TagFilterSet
 from ..tags.models import Tag
 from ..users.filterset import UserFilterSet
@@ -25,11 +25,11 @@ from .serializers import (
     CaseAutocompleteSerializer,
     ChannelAutocompleteSerializer,
     DocumentTypeAutocompleteSerializer,
-    ReferenceNumberAutocompleteSerializer,
     EventAutocompleteSerializer,
     FeatureAutocompleteSerializer,
     FeatureOptionAutocompleteSerializer,
     InstitutionAutocompleteSerializer,
+    ReferenceNumberAutocompleteSerializer,
     TagAutocompleteSerializer,
     UserAutocompleteSerializer,
 )

--- a/backend-project/small_eod/search/tests/mixins.py
+++ b/backend-project/small_eod/search/tests/mixins.py
@@ -1,9 +1,9 @@
 class SearchQueryMixin:
-    def get_response_for_query(self, query):
+    def get_response_for_query(self, query, **data):
         self.login_required()
         return self.client.get(
             self.get_url(name="list", **self.get_extra_kwargs()),
-            data={"query": query},
+            data={"query": query, **data},
         )
 
     def assertResultEqual(self, response, items):

--- a/frontend-project/src/components/FetchSelect.tsx
+++ b/frontend-project/src/components/FetchSelect.tsx
@@ -36,8 +36,9 @@ export function FetchSelect<
   value?: ValueType;
   labelField?: SearchField;
 }) {
-  const [isFetching, setFetching] = useState(false);
-  const [shownOptions, setShownOptions] = useState<OptionsType[]>([]);
+  const [isFetchingRelatedItems, setFetchingRelatedItems] = useState(false);
+  const [relatedItems, setRelatedItems] = useState<OptionsType[]>([]);
+  const [isFetchingAutocompleteOptions, setFetchingAutocompleteOptions] = useState(false);
   const [autocompleteOptions, setAutocompleteOptions] = useState<OptionsType[]>([]);
   const { debouncePromise } = useDebounce();
   const searchField = labelField || 'name';
@@ -59,56 +60,87 @@ export function FetchSelect<
     );
   }
 
-  // Call the autocomplete api once to convert field ids, fetched from the object's detail endpoint,
-  // into human readable names.
+  // Call the autocomplete api to convert field ids, fetched from the object's detail endpoint,
+  // into human readable names. Expected to be called once per select field.
   // Uses the autocomplete API for (id => name) mapping for consistency - subsequent calls, triggered
   // by user input, will receive (id, name) pairs from the same API.
+  function fetchRelatedItems(arrayValue: Array<number>) {
+    return autocompleteFunction({
+      query: QQ.in('id', arrayValue),
+      pageSize: 10,
+    }).then(extractOptionsFromApiResults);
+  }
+
+  // Request autocomplete suggestions from the backend.
+  function fetchSuggestions(search: string) {
+    return autocompleteFunction({
+      query: QQ.icontains(searchField, search),
+      pageSize: 10,
+    }).then(extractOptionsFromApiResults);
+  }
+
   useEffect(() => {
+    // 1. Map related items' ids (e.g. the current channel id) to a human readable name.
+
+    // Convert current value to an array.
+    // For multiselect fields, the value will already be an array.
     const arrayValue = Array.isArray(value) ? value : [value];
+
     if (
       typeof value === 'undefined' ||
       value === null ||
       arrayValue.length === 0 ||
+      // Tags are already provided as human readable names - no need to fetch anything.
       mode === 'tags'
-    )
-      return;
-    setShownOptions([]);
-    setFetching(true);
+    ) {
+      // Noop.
+      // Nothing to fetch.
+    } else {
+      setRelatedItems([]);
+      setFetchingRelatedItems(true);
 
-    autocompleteFunction({
-      query: QQ.in('id', arrayValue),
-      pageSize: 10,
-    })
+      fetchRelatedItems(arrayValue)
+        .then(autocompleteResults => {
+          setRelatedItems(autocompleteResults);
+        })
+        .catch(onError)
+        .finally(() => setFetchingRelatedItems(false));
+    }
+
+    // 2. Fetch an initial set of suggestions to display in the select component,
+    // before the user had a chance to type anything in the search field.
+    setAutocompleteOptions([]);
+    setFetchingAutocompleteOptions(true);
+
+    fetchSuggestions('')
       .then(autocompleteResults => {
-        setShownOptions(extractOptionsFromApiResults(autocompleteResults));
+        setAutocompleteOptions(autocompleteResults);
       })
       .catch(onError)
-      .finally(() => setFetching(false));
+      .finally(() => setFetchingAutocompleteOptions(false));
   }, []);
 
   // Fetch (id, name) pairs matching the search string.
   // Invoked on every keystroke, after a short delay.
   const debounceFetcher = (search: string) => {
-    if (!search) return [];
     setAutocompleteOptions([]);
-    setFetching(true);
+    setFetchingAutocompleteOptions(true);
 
     return debouncePromise(() =>
-      autocompleteFunction({
-        query: QQ.icontains(searchField, search),
-        pageSize: 10,
-      })
+      fetchSuggestions(search)
         .then(autocompleteResults => {
-          setAutocompleteOptions(extractOptionsFromApiResults(autocompleteResults));
+          setAutocompleteOptions(autocompleteResults);
         })
         .catch(onError)
-        .finally(() => setFetching(false)),
+        .finally(() => setFetchingAutocompleteOptions(false)),
     );
   };
 
   // All options to display to the user.
   // Sets may overlap - remove duplicates to avoid duplicate rendering issues.
-  const options = sortBy(unionBy(shownOptions, autocompleteOptions, 'value'), 'label');
+  const options = sortBy(unionBy(relatedItems, autocompleteOptions, 'value'), 'label');
+
+  const isFetching = isFetchingRelatedItems || isFetchingAutocompleteOptions;
 
   return (
     <Select<OptionsType>

--- a/frontend-project/src/components/FetchSelect.tsx
+++ b/frontend-project/src/components/FetchSelect.tsx
@@ -99,7 +99,10 @@ export function FetchSelect<
       setRelatedItems([]);
       setFetchingRelatedItems(true);
 
-      fetchRelatedItems(arrayValue)
+      // NOTE(rwakulszowa): `ValueType` is a bit complicated - converting it to
+      // an array of numbers in a type safe way may require refactoring the
+      // code a bit, hence a manual cast.
+      fetchRelatedItems(arrayValue as Array<number>)
         .then(autocompleteResults => {
           setRelatedItems(autocompleteResults);
         })


### PR DESCRIPTION
Fixes #948 

Sortowanie odpowiedzi autocomplete na podstawie podanego parametru `case`.

TODO: Wymagana zmiana na froncie (podanie argumentu `case` przy zapytaniu)

Dodana funkcjonalność:
- każde pole `Select` na start odpytuje autocomplete API o początkowy zestaw sugestii. Po kliknięciu w pole użytkownik zawsze otrzyma jakieś sugestie (o ile odpowiednie dane są w bazie, rzecz jasna), bez potrzeby wpisywania niczego w pole tekstowe. Po wpisaniu tekstu użytkownik otrzyma sugestie na podstawie tekstu, tak jak do tej pory.
- dla niektórych typów pół (na ten moment - tylko Instytucja), klient poda dodatkowo powiązane id sprawy. Sugestie autocomplete będą preferowały obiekty powiązane z daną sprawą, tj. jeśli pasujących sugestii jest 100, a klient wyświetla ich max. 20, to system zwróci w pierwszej kolejności obiekty przypisane do danej sprawy.
  Ważne: dla wygody użytkownika, sugestie są sortowane alfabetycznie przed wyświetleniem, tj. system postara się, żeby lista sugestii zawierała powiązane obiekty (instytucje), ale *nie* zagwarantuje, że będą one na samej górze widocznej listy - końcowa lista zawiera dane w alfabetycznej kolejności.


https://user-images.githubusercontent.com/10756296/122412624-04eadc00-cf86-11eb-8784-8df6a2b44802.mp4



@ad-m :
- czy konieczne będzie tutaj wygenerowanie SDK, żeby użyć nowego parametru?
- czym są "sygnatury" wspomniane w #948?
- czy opisane wyżej podejście spełnia wymagania?
- nowa funkcjonalność teoretycznie otwiera możliwość wykrycia które sprawy są powiązane z którymi instytucjami (tj. użytkownik może odpytywać API autocomplete z nowym polem `case` i na podstawie zwracanych wyników dowiedzieć się która sprawa jest powiązana z daną instytucją; nie sprawdzamy tutaj żadnych uprawnień - czy to problem, czy (póki co?) zakładamy, że dostęp do odczytu tego typu danych jest raczej powszechny / nie mniej powszechny niż dostęp do autocomplete API?)

