### PR TITLE
Load initial autocomplete suggestions + ReferenceNumber autocomplete backend changes

### DIFF
--- a/backend-project/small_eod/autocomplete/serializers.py
+++ b/backend-project/small_eod/autocomplete/serializers.py
@@ -6,7 +6,7 @@ from ..channels.models import Channel
 from ..events.models import Event
 from ..features.models import Feature, FeatureOption
 from ..institutions.models import Institution
-from ..letters.models import DocumentType
+from ..letters.models import DocumentType, ReferenceNumber
 from ..tags.models import Tag
 from ..users.models import User
 
@@ -32,6 +32,12 @@ class ChannelAutocompleteSerializer(serializers.ModelSerializer):
 class DocumentTypeAutocompleteSerializer(serializers.ModelSerializer):
     class Meta:
         model = DocumentType
+        fields = ["id", "name"]
+
+
+class ReferenceNumberAutocompleteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ReferenceNumber
         fields = ["id", "name"]
 
 

--- a/backend-project/small_eod/autocomplete/tests/test_serializers.py
+++ b/backend-project/small_eod/autocomplete/tests/test_serializers.py
@@ -16,11 +16,11 @@ from ..serializers import (
     CaseAutocompleteSerializer,
     ChannelAutocompleteSerializer,
     DocumentTypeAutocompleteSerializer,
-    ReferenceNumberAutocompleteSerializer,
     EventAutocompleteSerializer,
     FeatureAutocompleteSerializer,
     FeatureOptionAutocompleteSerializer,
     InstitutionAutocompleteSerializer,
+    ReferenceNumberAutocompleteSerializer,
     TagAutocompleteSerializer,
     UserAutocompleteSerializer,
 )

--- a/backend-project/small_eod/autocomplete/tests/test_serializers.py
+++ b/backend-project/small_eod/autocomplete/tests/test_serializers.py
@@ -8,7 +8,7 @@ from ...features.factories import FeatureFactory, FeatureOptionFactory
 from ...generic.mixins import AuthRequiredMixin
 from ...generic.tests.test_serializers import ResourceSerializerMixin
 from ...institutions.factories import InstitutionFactory
-from ...letters.factories import DocumentTypeFactory
+from ...letters.factories import DocumentTypeFactory, ReferenceNumberFactory
 from ...tags.factories import TagFactory
 from ...users.factories import UserFactory
 from ..serializers import (
@@ -16,6 +16,7 @@ from ..serializers import (
     CaseAutocompleteSerializer,
     ChannelAutocompleteSerializer,
     DocumentTypeAutocompleteSerializer,
+    ReferenceNumberAutocompleteSerializer,
     EventAutocompleteSerializer,
     FeatureAutocompleteSerializer,
     FeatureOptionAutocompleteSerializer,
@@ -51,6 +52,13 @@ class DocumentTypeAutocompleteSerializerTestCase(
 ):
     serializer_class = DocumentTypeAutocompleteSerializer
     factory_class = DocumentTypeFactory
+
+
+class ReferenceNumberAutocompleteSerializerTestCase(
+    ResourceSerializerMixin, AuthRequiredMixin, TestCase
+):
+    serializer_class = ReferenceNumberAutocompleteSerializer
+    factory_class = ReferenceNumberFactory
 
 
 class EventAutocompleteSerializerTestCase(

--- a/backend-project/small_eod/autocomplete/tests/test_views.py
+++ b/backend-project/small_eod/autocomplete/tests/test_views.py
@@ -7,10 +7,7 @@ from ...events.factories import EventFactory
 from ...features.factories import FeatureFactory, FeatureOptionFactory
 from ...generic.tests.test_views import ReadOnlyViewSetMixin
 from ...institutions.factories import InstitutionFactory
-from ...letters.factories import (
-    DocumentTypeFactory,
-    ReferenceNumberFactory,
-)
+from ...letters.factories import DocumentTypeFactory, ReferenceNumberFactory
 from ...search.tests.mixins import SearchQueryMixin
 from ...tags.factories import TagFactory
 from ...users.factories import UserFactory

--- a/backend-project/small_eod/autocomplete/tests/test_views.py
+++ b/backend-project/small_eod/autocomplete/tests/test_views.py
@@ -7,7 +7,10 @@ from ...events.factories import EventFactory
 from ...features.factories import FeatureFactory, FeatureOptionFactory
 from ...generic.tests.test_views import ReadOnlyViewSetMixin
 from ...institutions.factories import InstitutionFactory
-from ...letters.factories import DocumentTypeFactory
+from ...letters.factories import (
+    DocumentTypeFactory,
+    ReferenceNumberFactory,
+)
 from ...search.tests.mixins import SearchQueryMixin
 from ...tags.factories import TagFactory
 from ...users.factories import UserFactory
@@ -49,6 +52,17 @@ class DocumentTypeAutocompleteViewSetTestCase(
 ):
     basename = "autocomplete_document_type"
     factory_class = DocumentTypeFactory
+
+    def validate_item(self, item):
+        self.assertEqual(item["id"], self.obj.id)
+        self.assertEqual(item["name"], self.obj.name)
+
+
+class ReferenceNumberAutocompleteViewSetTestCase(
+    ReadOnlyViewSetMixin, SearchQueryMixin, TestCase
+):
+    basename = "autocomplete_reference_number"
+    factory_class = ReferenceNumberFactory
 
     def validate_item(self, item):
         self.assertEqual(item["id"], self.obj.id)

--- a/backend-project/small_eod/autocomplete/urls.py
+++ b/backend-project/small_eod/autocomplete/urls.py
@@ -6,11 +6,11 @@ from .views import (
     CaseAutocompleteViewSet,
     ChannelAutocompleteViewSet,
     DocumentTypeAutocompleteViewSet,
-    ReferenceNumberAutocompleteViewSet,
     EventAutocompleteViewSet,
     FeatureAutocompleteViewSet,
     FeatureOptionAutocompleteViewSet,
     InstitutionAutocompleteViewSet,
+    ReferenceNumberAutocompleteViewSet,
     TagAutocompleteViewSet,
     UserAutocompleteViewSet,
 )

--- a/backend-project/small_eod/autocomplete/urls.py
+++ b/backend-project/small_eod/autocomplete/urls.py
@@ -6,6 +6,7 @@ from .views import (
     CaseAutocompleteViewSet,
     ChannelAutocompleteViewSet,
     DocumentTypeAutocompleteViewSet,
+    ReferenceNumberAutocompleteViewSet,
     EventAutocompleteViewSet,
     FeatureAutocompleteViewSet,
     FeatureOptionAutocompleteViewSet,
@@ -24,6 +25,11 @@ router.register("cases", CaseAutocompleteViewSet, "autocomplete_case")
 router.register("channels", ChannelAutocompleteViewSet, "autocomplete_channel")
 router.register(
     "document_types", DocumentTypeAutocompleteViewSet, "autocomplete_document_type"
+)
+router.register(
+    "reference_numbers",
+    ReferenceNumberAutocompleteViewSet,
+    "autocomplete_reference_number",
 )
 router.register("events", EventAutocompleteViewSet, "autocomplete_event")
 router.register("features", FeatureAutocompleteViewSet, "autocomplete_feature")

--- a/backend-project/small_eod/autocomplete/views.py
+++ b/backend-project/small_eod/autocomplete/views.py
@@ -13,8 +13,8 @@ from ..features.filterset import FeatureFilterSet, FeatureOptionFilterSet
 from ..features.models import Feature, FeatureOption
 from ..institutions.filterset import InstitutionFilterSet
 from ..institutions.models import Institution
-from ..letters.filterset import DocumentTypeFilterSet
-from ..letters.models import DocumentType
+from ..letters.filterset import DocumentTypeFilterSet, ReferenceNumberFilterSet
+from ..letters.models import DocumentType, ReferenceNumber
 from ..tags.filterset import TagFilterSet
 from ..tags.models import Tag
 from ..users.filterset import UserFilterSet
@@ -24,6 +24,7 @@ from .serializers import (
     CaseAutocompleteSerializer,
     ChannelAutocompleteSerializer,
     DocumentTypeAutocompleteSerializer,
+    ReferenceNumberAutocompleteSerializer,
     EventAutocompleteSerializer,
     FeatureAutocompleteSerializer,
     FeatureOptionAutocompleteSerializer,
@@ -87,6 +88,13 @@ class InstitutionAutocompleteViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = InstitutionAutocompleteSerializer
     filter_backends = (DjangoFilterBackend,)
     filterset_class = InstitutionFilterSet
+
+
+class ReferenceNumberAutocompleteViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = ReferenceNumber.objects.only("id", "name").all()
+    serializer_class = ReferenceNumberAutocompleteSerializer
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = ReferenceNumberFilterSet
 
 
 class TagAutocompleteViewSet(viewsets.ReadOnlyModelViewSet):

--- a/backend-project/small_eod/autocomplete/views.py
+++ b/backend-project/small_eod/autocomplete/views.py
@@ -24,11 +24,11 @@ from .serializers import (
     CaseAutocompleteSerializer,
     ChannelAutocompleteSerializer,
     DocumentTypeAutocompleteSerializer,
-    ReferenceNumberAutocompleteSerializer,
     EventAutocompleteSerializer,
     FeatureAutocompleteSerializer,
     FeatureOptionAutocompleteSerializer,
     InstitutionAutocompleteSerializer,
+    ReferenceNumberAutocompleteSerializer,
     TagAutocompleteSerializer,
     UserAutocompleteSerializer,
 )


### PR DESCRIPTION
- frontend pobiera i wyświetla sugestie po pierwszym kliknięciu w pole
- API do uzupełniania ReferenceNumber
  O ile się rozumiem, zmiana jest konieczna do wygenerowania SDK - dopiero kolejny PR będzie mógł wprowadzić zmiany dla autouzupełniania ReferenceNumber, ponieważ póki co SDK go nie wspiera.