### PR TITLE
Enable npm manager for autoupdate SDK

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,5 +23,5 @@
   "docker": {
     "pinDigests": true
   },
-  "enabledManagers": ["docker-compose", "dockerfile", "github-actions"]
+  "enabledManagers": ["docker-compose", "dockerfile", "github-actions", "npm"]
 }


### PR DESCRIPTION
See watchdogpolska/small-eod-sdk-javascript#14 for missing updates of SDK in that repository. I think (I have look at that quickly only) that changes MIGHT resume updates of `small_eod_client` in that repository.