### PR TITLE
Order the letters by date descending on backend

### DIFF
--- a/backend-project/small_eod/letters/views.py
+++ b/backend-project/small_eod/letters/views.py
@@ -44,7 +44,7 @@ class LetterViewSet(viewsets.ModelViewSet, NotificationsView):
         "modified_on",
         "modified_by__username",
     ]
-    ordering = ['-date']
+    ordering = ["-date"]
 
 
 class DocumentTypeViewSet(viewsets.ModelViewSet):

--- a/backend-project/small_eod/letters/views.py
+++ b/backend-project/small_eod/letters/views.py
@@ -44,6 +44,7 @@ class LetterViewSet(viewsets.ModelViewSet, NotificationsView):
         "modified_on",
         "modified_by__username",
     ]
+    ordering = ['-date']
 
 
 class DocumentTypeViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
Fixes https://github.com/watchdogpolska/small_eod/issues/946

Na froncie nie można w żaden sposób zmieniać sortowania, więc proponuję domyślnie z backendu zwracać listy posortowane w oczekiwany sposób, a gdy znajdzie się ktoś kto będzie chciał dorobić ten feature na froncie wtedy będzie można dodać taką opcję.